### PR TITLE
Fix array error overwriting

### DIFF
--- a/.changeset/honest-parents-tan.md
+++ b/.changeset/honest-parents-tan.md
@@ -1,0 +1,5 @@
+---
+'@reactive-forms/core': patch
+---
+
+Fixed bug when error set on array type was overwritten by errors from any item in array (error object was replaced with array)

--- a/packages/core/src/hooks/useForm.ts
+++ b/packages/core/src/hooks/useForm.ts
@@ -20,6 +20,7 @@ import { FormMeta } from '../typings/FormMeta';
 import { SubmitAction } from '../typings/SubmitAction';
 import { deepRemoveEmpty } from '../utils/deepRemoveEmpty';
 import { excludeOverlaps } from '../utils/excludeOverlaps';
+import { mergeErrors } from '../utils/mergeErrors';
 import { overrideMerge } from '../utils/overrideMerge';
 import { runYupSchema } from '../utils/runYupSchema';
 import { setNestedValues } from '../utils/setNestedValues';
@@ -172,7 +173,8 @@ export const useForm = <Values extends object>(initialConfig: FormConfig<Values>
 			const validateFormFnErrors: FieldError<Values> = validatorResultToError(await validateFormFn?.(values));
 			const schemaErrors = await runFormValidationSchema(values);
 
-			const allErrors = deepRemoveEmpty(merge({}, registryErrors, validateFormFnErrors, schemaErrors)) ?? {};
+			const allErrors =
+				deepRemoveEmpty(mergeErrors({}, registryErrors, validateFormFnErrors, schemaErrors)) ?? {};
 
 			if (!disablePureFieldsValidation) {
 				return allErrors as FieldError<Values>;

--- a/packages/core/src/hooks/useValidationRegistry.ts
+++ b/packages/core/src/hooks/useValidationRegistry.ts
@@ -1,7 +1,5 @@
 import { useCallback, useRef } from 'react';
-import isPlainObject from 'lodash/isPlainObject';
 import merge from 'lodash/merge';
-import mergeWith from 'lodash/mergeWith';
 import { createPxth, deepGet, deepSet, getPxthSegments, isInnerPxth, Pxth, samePxth } from 'pxth';
 import { PxthMap } from 'stocked';
 import invariant from 'tiny-invariant';

--- a/packages/core/src/utils/mergeErrors.ts
+++ b/packages/core/src/utils/mergeErrors.ts
@@ -1,0 +1,14 @@
+import isPlainObject from 'lodash/isPlainObject';
+import mergeWith from 'lodash/mergeWith';
+
+const errorsMergeCustomizer = (target: unknown, source: unknown): unknown => {
+	if (Array.isArray(target) && isPlainObject(source)) {
+		return mergeWith(target, Object.assign([], source), errorsMergeCustomizer);
+	}
+	if (Array.isArray(source) && isPlainObject(target)) {
+		return mergeWith(source, Object.assign([], target), errorsMergeCustomizer);
+	}
+};
+
+export const mergeErrors = (target: unknown, ...sources: unknown[]) =>
+	mergeWith(target, ...sources, errorsMergeCustomizer);

--- a/packages/core/tests/hooks/useValidationRegistry.test.tsx
+++ b/packages/core/tests/hooks/useValidationRegistry.test.tsx
@@ -296,4 +296,24 @@ describe('useValidationRegistry', () => {
 		unregisterRootValidator();
 		unregisterChildValidator();
 	});
+
+	it('Should merge error, set on array, with array items errors', async () => {
+		const { result } = renderUseValidationRegistry();
+		type TestType = { array: unknown[] };
+		const path = createPxth<{ array: unknown[] }>([]);
+
+		const arrayValidator = jest.fn(() => 'arrayError');
+		const arrayItemValidator = jest.fn(() => 'itemError');
+
+		const unregisterArrayItemValidator = result.current.registerValidator(path.array[0], arrayItemValidator);
+		const unregisterArrayValidator = result.current.registerValidator(path.array, arrayValidator);
+
+		const errors = (await result.current.validateBranch(path, {})).errors as FieldError<TestType>;
+
+		expect(errors.array?.$error).toStrictEqual('arrayError');
+		expect(errors.array?.[0]).toStrictEqual({ $error: 'itemError' });
+
+		unregisterArrayValidator();
+		unregisterArrayItemValidator();
+	});
 });

--- a/packages/core/tests/hooks/useValidationRegistry.test.tsx
+++ b/packages/core/tests/hooks/useValidationRegistry.test.tsx
@@ -297,7 +297,7 @@ describe('useValidationRegistry', () => {
 		unregisterChildValidator();
 	});
 
-	it('Should merge error, set on array, with array items errors', async () => {
+	it('Should merge error, set on array, with array items error', async () => {
 		const { result } = renderUseValidationRegistry();
 		type TestType = { array: unknown[] };
 		const path = createPxth<{ array: unknown[] }>([]);
@@ -305,8 +305,8 @@ describe('useValidationRegistry', () => {
 		const arrayValidator = jest.fn(() => 'arrayError');
 		const arrayItemValidator = jest.fn(() => 'itemError');
 
-		const unregisterArrayItemValidator = result.current.registerValidator(path.array[0], arrayItemValidator);
 		const unregisterArrayValidator = result.current.registerValidator(path.array, arrayValidator);
+		const unregisterArrayItemValidator = result.current.registerValidator(path.array[0], arrayItemValidator);
 
 		const errors = (await result.current.validateBranch(path, {})).errors as FieldError<TestType>;
 


### PR DESCRIPTION
When error is set on array type path (for example {emails: []}), and there is an error inside array item (for example emails[0].emailAddress) error object set on array is being overwritten by array of specific error objects and original error message is not merged.